### PR TITLE
Detach view from presenter to avoid memory leaks

### DIFF
--- a/app/src/main/java/uk/co/ribot/androidboilerplate/ui/main/MainActivity.java
+++ b/app/src/main/java/uk/co/ribot/androidboilerplate/ui/main/MainActivity.java
@@ -58,6 +58,13 @@ public class MainActivity extends BaseActivity implements MainMvpView {
         }
     }
 
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+
+        mMainPresenter.detachView();
+    }
+
     /***** MVP View methods implementation *****/
 
     @Override


### PR DESCRIPTION
Currently, the MainActivity is never detached from the presenter that will hold on to that reference forever, thus, leaking memory.

With this change we call the presenter's detachView() when the MainActivity is destroyed.

Otherwise, this is what happens after rotating the screen (27 instances of MainActivity):
![screen shot 2016-01-05 at 09 26 39](https://cloud.githubusercontent.com/assets/242983/12110753/d8fc1590-b38f-11e5-91a8-cd5b42503310.png)

