### PR TITLE
espresso address updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Libraries and tools included:
 - [Timber](https://github.com/JakeWharton/timber)
 - [Glide](https://github.com/bumptech/glide)
 - [Otto](http://square.github.io/otto/) event bus
-- Functional tests with [Espresso](https://code.google.com/p/android-test-kit/wiki/Espresso)
+- Functional tests with [Espresso](https://google.github.io/android-testing-support-library/docs/espresso/index.html)
 - [Robolectric](http://robolectric.org/)
 - [Mockito](http://mockito.org/)
 - [Checkstyle](http://checkstyle.sourceforge.net/), [PMD](https://pmd.github.io/) and [Findbugs](http://findbugs.sourceforge.net/) for code analysis


### PR DESCRIPTION
espresso address in original README.md is not right, updated to the right one: https://google.github.io/android-testing-support-library/docs/espresso/index.html.