### PR TITLE
Presenters survive configuration changes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     final PLAY_SERVICES_VERSION = '9.2.0'
     final SUPPORT_LIBRARY_VERSION = '24.0.0'
     final RETROFIT_VERSION = '2.1.0'
-    final DAGGER_VERSION = '2.4'
+    final DAGGER_VERSION = '2.5'
     final DEXMAKER_VERSION = '1.4'
     final HAMCREST_VERSION = '1.3'
     final ESPRESSO_VERSION = '2.2.1'

--- a/app/src/androidTest/java/uk/co/ribot/androidboilerplate/MainActivityTest.java
+++ b/app/src/androidTest/java/uk/co/ribot/androidboilerplate/MainActivityTest.java
@@ -16,8 +16,8 @@ import java.util.List;
 
 import rx.Observable;
 import uk.co.ribot.androidboilerplate.data.model.Ribot;
-import uk.co.ribot.androidboilerplate.test.common.TestDataFactory;
 import uk.co.ribot.androidboilerplate.test.common.TestComponentRule;
+import uk.co.ribot.androidboilerplate.test.common.TestDataFactory;
 import uk.co.ribot.androidboilerplate.ui.main.MainActivity;
 
 import static android.support.test.espresso.Espresso.onView;

--- a/app/src/main/java/uk/co/ribot/androidboilerplate/injection/ConfigPersistent.java
+++ b/app/src/main/java/uk/co/ribot/androidboilerplate/injection/ConfigPersistent.java
@@ -1,0 +1,17 @@
+package uk.co.ribot.androidboilerplate.injection;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.inject.Scope;
+
+import uk.co.ribot.androidboilerplate.injection.component.ConfigPersistentComponent;
+
+/**
+ * A scoping annotation to permit dependencies conform to the life of the
+ * {@link ConfigPersistentComponent}
+ */
+@Scope
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ConfigPersistent {
+}

--- a/app/src/main/java/uk/co/ribot/androidboilerplate/injection/component/ActivityComponent.java
+++ b/app/src/main/java/uk/co/ribot/androidboilerplate/injection/component/ActivityComponent.java
@@ -1,6 +1,6 @@
 package uk.co.ribot.androidboilerplate.injection.component;
 
-import dagger.Component;
+import dagger.Subcomponent;
 import uk.co.ribot.androidboilerplate.injection.PerActivity;
 import uk.co.ribot.androidboilerplate.injection.module.ActivityModule;
 import uk.co.ribot.androidboilerplate.ui.main.MainActivity;
@@ -9,7 +9,7 @@ import uk.co.ribot.androidboilerplate.ui.main.MainActivity;
  * This component inject dependencies to all Activities across the application
  */
 @PerActivity
-@Component(dependencies = ApplicationComponent.class, modules = ActivityModule.class)
+@Subcomponent(modules = ActivityModule.class)
 public interface ActivityComponent {
 
     void inject(MainActivity mainActivity);

--- a/app/src/main/java/uk/co/ribot/androidboilerplate/injection/component/ConfigPersistentComponent.java
+++ b/app/src/main/java/uk/co/ribot/androidboilerplate/injection/component/ConfigPersistentComponent.java
@@ -1,0 +1,21 @@
+package uk.co.ribot.androidboilerplate.injection.component;
+
+import dagger.Component;
+import uk.co.ribot.androidboilerplate.injection.ConfigPersistent;
+import uk.co.ribot.androidboilerplate.injection.module.ActivityModule;
+import uk.co.ribot.androidboilerplate.ui.base.BaseActivity;
+
+/**
+ * A dagger component that will live during the lifecycle of an Activity but it won't
+ * be destroy during configuration changes. Check {@link BaseActivity} to see how this components
+ * survives configuration changes.
+ * Use the {@link ConfigPersistent} scope to annotate dependencies that need to survive
+ * configuration changes (for example Presenters).
+ */
+@ConfigPersistent
+@Component(dependencies = ApplicationComponent.class)
+public interface ConfigPersistentComponent {
+
+    ActivityComponent activityComponent(ActivityModule activityModule);
+
+}

--- a/app/src/main/java/uk/co/ribot/androidboilerplate/ui/base/BaseActivity.java
+++ b/app/src/main/java/uk/co/ribot/androidboilerplate/ui/base/BaseActivity.java
@@ -3,27 +3,69 @@ package uk.co.ribot.androidboilerplate.ui.base;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import timber.log.Timber;
 import uk.co.ribot.androidboilerplate.BoilerplateApplication;
 import uk.co.ribot.androidboilerplate.injection.component.ActivityComponent;
-import uk.co.ribot.androidboilerplate.injection.component.DaggerActivityComponent;
+import uk.co.ribot.androidboilerplate.injection.component.ConfigPersistentComponent;
+import uk.co.ribot.androidboilerplate.injection.component.DaggerConfigPersistentComponent;
 import uk.co.ribot.androidboilerplate.injection.module.ActivityModule;
 
+/**
+ * Abstract activity that every other Activity in this application must implement. It handles
+ * creation of Dagger components and makes sure that instances of ConfigPersistentComponent are kept
+ * across configuration changes.
+ */
 public class BaseActivity extends AppCompatActivity {
 
+    private static final String KEY_ACTIVITY_ID = "KEY_ACTIVITY_ID";
+    private static final AtomicLong NEXT_ID = new AtomicLong(0);
+    private static final Map<Long, ConfigPersistentComponent> sComponentsMap = new HashMap<>();
+
     private ActivityComponent mActivityComponent;
+    private long mActivityId;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-    }
 
-    public ActivityComponent getActivityComponent() {
-        if (mActivityComponent == null) {
-            mActivityComponent = DaggerActivityComponent.builder()
-                    .activityModule(new ActivityModule(this))
+        // Create the ActivityComponent and reuses cached ConfigPersistentComponent if this is
+        // being called after a configuration change.
+        mActivityId = savedInstanceState != null ?
+                savedInstanceState.getLong(KEY_ACTIVITY_ID) : NEXT_ID.getAndIncrement();
+        ConfigPersistentComponent configPersistentComponent;
+        if (!sComponentsMap.containsKey(mActivityId)) {
+            Timber.i("Creating new ConfigPersistentComponent id=%d", mActivityId);
+            configPersistentComponent = DaggerConfigPersistentComponent.builder()
                     .applicationComponent(BoilerplateApplication.get(this).getComponent())
                     .build();
+            sComponentsMap.put(mActivityId, configPersistentComponent);
+        } else {
+            Timber.i("Reusing ConfigPersistentComponent id=%d", mActivityId);
+            configPersistentComponent = sComponentsMap.get(mActivityId);
         }
+        mActivityComponent = configPersistentComponent.activityComponent(new ActivityModule(this));
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putLong(KEY_ACTIVITY_ID, mActivityId);
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (!isChangingConfigurations()) {
+            Timber.i("Clearing ConfigPersistentComponent id=%d", mActivityId);
+            sComponentsMap.remove(mActivityId);
+        }
+        super.onDestroy();
+    }
+
+    public ActivityComponent activityComponent() {
         return mActivityComponent;
     }
 

--- a/app/src/main/java/uk/co/ribot/androidboilerplate/ui/base/BaseActivity.java
+++ b/app/src/main/java/uk/co/ribot/androidboilerplate/ui/base/BaseActivity.java
@@ -16,7 +16,7 @@ import uk.co.ribot.androidboilerplate.injection.module.ActivityModule;
 
 /**
  * Abstract activity that every other Activity in this application must implement. It handles
- * creation of Dagger components and makes sure that instances of ConfigPersistentComponent are kept
+ * creation of Dagger components and makes sure that instances of ConfigPersistentComponent survive
  * across configuration changes.
  */
 public class BaseActivity extends AppCompatActivity {

--- a/app/src/main/java/uk/co/ribot/androidboilerplate/ui/main/MainActivity.java
+++ b/app/src/main/java/uk/co/ribot/androidboilerplate/ui/main/MainActivity.java
@@ -44,7 +44,7 @@ public class MainActivity extends BaseActivity implements MainMvpView {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        getActivityComponent().inject(this);
+        activityComponent().inject(this);
         setContentView(R.layout.activity_main);
         ButterKnife.bind(this);
 

--- a/app/src/main/java/uk/co/ribot/androidboilerplate/ui/main/MainPresenter.java
+++ b/app/src/main/java/uk/co/ribot/androidboilerplate/ui/main/MainPresenter.java
@@ -11,8 +11,10 @@ import rx.schedulers.Schedulers;
 import timber.log.Timber;
 import uk.co.ribot.androidboilerplate.data.DataManager;
 import uk.co.ribot.androidboilerplate.data.model.Ribot;
+import uk.co.ribot.androidboilerplate.injection.ConfigPersistent;
 import uk.co.ribot.androidboilerplate.ui.base.BasePresenter;
 
+@ConfigPersistent
 public class MainPresenter extends BasePresenter<MainMvpView> {
 
     private final DataManager mDataManager;


### PR DESCRIPTION
This PR implements a way of injecting instances of classes that should conform to the lifecycle of Activities, but at the same time survive configuration changes - for example Presenters. It allows annotating those classes with a Dagger scope `@ConfigPersistent`. All the classes annotated with that scope will survive configuration changes. 

This implementation works by having a separate Dagger component (`ConfigPersistentComponent `) that is in charge of injecting the objects that should survive configuration changes. The `BaseActivity` makes sure that instances of `ConfigPersistentComponent` are kept in a `static Map`. If the Activity is being destroyed due to a configuration changes, the existing instance of `ConfigPersistentComponent` is retrieved from the Map and reused. If the Activity is being destroyed forever, then the instance of `ConfigPersistentComponent` is cleared from the Map.