### PR TITLE
subscription leaks removed

### DIFF
--- a/app/src/main/java/uk/co/ribot/androidboilerplate/ui/main/MainPresenter.java
+++ b/app/src/main/java/uk/co/ribot/androidboilerplate/ui/main/MainPresenter.java
@@ -13,6 +13,7 @@ import uk.co.ribot.androidboilerplate.data.DataManager;
 import uk.co.ribot.androidboilerplate.data.model.Ribot;
 import uk.co.ribot.androidboilerplate.injection.ConfigPersistent;
 import uk.co.ribot.androidboilerplate.ui.base.BasePresenter;
+import uk.co.ribot.androidboilerplate.util.RxUtil;
 
 @ConfigPersistent
 public class MainPresenter extends BasePresenter<MainMvpView> {
@@ -38,6 +39,7 @@ public class MainPresenter extends BasePresenter<MainMvpView> {
 
     public void loadRibots() {
         checkViewAttached();
+        RxUtil.unsubscribe(mSubscription);
         mSubscription = mDataManager.getRibots()
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/java/uk/co/ribot/androidboilerplate/util/RxUtil.java
+++ b/app/src/main/java/uk/co/ribot/androidboilerplate/util/RxUtil.java
@@ -5,7 +5,7 @@ import rx.Subscription;
 public class RxUtil {
 
     public static void unsubscribe(Subscription subscription) {
-        if((subscription != null) && (!subscription.isUnsubscribed())) {
+        if (subscription != null && !subscription.isUnsubscribed()) {
             subscription.unsubscribe();
         }
     }

--- a/app/src/main/java/uk/co/ribot/androidboilerplate/util/RxUtil.java
+++ b/app/src/main/java/uk/co/ribot/androidboilerplate/util/RxUtil.java
@@ -1,0 +1,12 @@
+package uk.co.ribot.androidboilerplate.util;
+
+import rx.Subscription;
+
+public class RxUtil {
+
+    public static void unsubscribe(Subscription subscription) {
+        if((subscription != null) && (!subscription.isUnsubscribed())) {
+            subscription.unsubscribe();
+        }
+    }
+}


### PR DESCRIPTION
Hi!

Second and following calls to `MainPresenter.loadRepos()` probably will cause the subscriptions leaks, because you don't unsubscribe from previous and lose reference to them. One quick suggestion:  unsubscribe from previous subscription before doing `mSubscription = mDataManager.getRepository()...`.