### PR TITLE
Updated checkstyle version for proper lambda support.

### DIFF
--- a/config/quality/quality.gradle
+++ b/config/quality/quality.gradle
@@ -15,7 +15,7 @@ apply plugin: 'findbugs'
 apply plugin: 'pmd'
 
 dependencies {
-    checkstyle 'com.puppycrawl.tools:checkstyle:6.5'
+    checkstyle 'com.puppycrawl.tools:checkstyle:6.11.1'
 }
 
 def qualityConfigDir = "$project.rootDir/config/quality";


### PR DESCRIPTION
Removes issues with checkstyle not understanding lambda notations, thus not showing any errors anymore. 