### PR TITLE
Fix: Proguard config to fix build.

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -36,6 +36,9 @@
 -dontnote retrofit2.Platform$IOS$MainThreadExecutor
 # Platform used when running on Java 8 VMs. Will not be used at runtime.
 -dontwarn retrofit2.Platform$Java8
+-dontwarn retrofit2.adapter.rxjava.CompletableHelper$CompletableCallAdapter
+-dontwarn retrofit2.adapter.rxjava.CompletableHelper$CompletableCallOnSubscribe
+-dontwarn retrofit2.adapter.rxjava.CompletableHelper$CompletableCallOnSubscribe$1
 # Retain generic type information for use by reflection by converters and adapters.
 -keepattributes Signature
 # Retain declared checked exceptions for use by a Proxy instance.


### PR DESCRIPTION
Add -dontwarn for rxjava adapters for retrofit 2. Now the repo can build a release build out of the box.