### PR TITLE
Update Mockito to 2.6.2 and remove dexmaker.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,6 +82,7 @@ dependencies {
     final SUPPORT_LIBRARY_VERSION = '24.2.1'
     final RETROFIT_VERSION = '2.1.0'
     final DAGGER_VERSION = '2.5'
+    final MOCKITO_VERSION = '2.6.2'
     final HAMCREST_VERSION = '1.3'
     final ESPRESSO_VERSION = '2.2.1'
     final RUNNER_VERSION = '0.4'
@@ -91,7 +92,7 @@ dependencies {
 
     def daggerCompiler = "com.google.dagger:dagger-compiler:$DAGGER_VERSION"
     def jUnit = "junit:junit:4.12"
-    def mockito = "org.mockito:mockito-core:1.10.19"
+    def mockito = "org.mockito:mockito-core:$MOCKITO_VERSION"
 
     // App Dependencies
     compile "com.google.android.gms:play-services-gcm:$PLAY_SERVICES_VERSION"
@@ -137,6 +138,7 @@ dependencies {
     // Instrumentation test dependencies
     androidTestCompile jUnit
     androidTestCompile mockito
+    androidTestCompile "org.mockito:mockito-android:$MOCKITO_VERSION"
     androidTestCompile "com.android.support:support-annotations:$SUPPORT_LIBRARY_VERSION"
     androidTestCompile("com.android.support.test.espresso:espresso-contrib:$ESPRESSO_VERSION") {
         exclude group: 'com.android.support', module: 'appcompat'
@@ -160,5 +162,3 @@ dependencies {
 tasks.matching {it instanceof Test}.all {
     testLogging.events = ["failed", "passed", "skipped"]
 }
-
-

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,7 +82,6 @@ dependencies {
     final SUPPORT_LIBRARY_VERSION = '24.2.1'
     final RETROFIT_VERSION = '2.1.0'
     final DAGGER_VERSION = '2.5'
-    final DEXMAKER_VERSION = '1.4'
     final HAMCREST_VERSION = '1.3'
     final ESPRESSO_VERSION = '2.2.1'
     final RUNNER_VERSION = '0.4'
@@ -147,9 +146,6 @@ dependencies {
     androidTestCompile "com.android.support.test.espresso:espresso-core:$ESPRESSO_VERSION"
     androidTestCompile "com.android.support.test:runner:$RUNNER_VERSION"
     androidTestCompile "com.android.support.test:rules:$RUNNER_VERSION"
-    androidTestCompile "com.crittercism.dexmaker:dexmaker:$DEXMAKER_VERSION"
-    androidTestCompile "com.crittercism.dexmaker:dexmaker-dx:$DEXMAKER_VERSION"
-    androidTestCompile "com.crittercism.dexmaker:dexmaker-mockito:$DEXMAKER_VERSION"
 
     // Unit tests dependencies
     testCompile jUnit


### PR DESCRIPTION
Since 2.6, Mockito tests can now be run on any android device or emulator without the need of third party dependencies.

[Source](https://www.reddit.com/r/androiddev/comments/5nj6lf/mockito_26_does_now_support_android/)